### PR TITLE
Reroute `System.Diagnostics.Debug` logging to VSC Debug Console 

### DIFF
--- a/src/DotNet.Meteor.Debug/MonoDebugSession.cs
+++ b/src/DotNet.Meteor.Debug/MonoDebugSession.cs
@@ -49,6 +49,9 @@ public partial class MonoDebugSession : DebugSession {
             if (isStdErr) this.sessionLogger.Error($"Mono: {text.Trim()}");
             else this.sessionLogger.Debug($"Mono: {text.Trim()}");
         };
+        this.session.DebugWriter = (int level, string category, string message) => {
+                OnOutputDataReceived("console", message);                
+        };
         this.session.TargetStopped += (sender, e) => {
             Stopped();
             SendEvent(Event.StoppedEvent, new BodyStopped((int)e.Thread.Id, "step"));

--- a/src/DotNet.Meteor.Debug/Session.cs
+++ b/src/DotNet.Meteor.Debug/Session.cs
@@ -112,7 +112,11 @@ public abstract class Session: IProcessLogger {
     }
 
     public void OnOutputDataReceived(string stdout) {
-        SendEvent(Event.OutputEvent, new BodyOutput("stdout", stdout.Trim() + Environment.NewLine));
+        OnOutputDataReceived("stdout", stdout);
+    }
+
+    public void OnOutputDataReceived(string category, string stdout) {
+        SendEvent(Event.OutputEvent, new BodyOutput(category, stdout.Trim() + Environment.NewLine));
     }
 
     public void OnErrorDataReceived(string stderr) {


### PR DESCRIPTION
instead of log file.

issue #39 

This is a quick fix to this issue.

<img width="667" alt="debug console mac fix" src="https://user-images.githubusercontent.com/640466/221409236-709114dd-29fd-4e76-9de6-62a2e89ae506.png">

