### PR TITLE
Add setting to default active device when code window started.

### DIFF
--- a/manifest/configuration.json
+++ b/manifest/configuration.json
@@ -11,6 +11,11 @@
           "type": "integer",
           "default": 55551,
           "description": "%configuration.description.monoSdbDebuggerPortApple%"
+        },
+        "dotnetMeteor.activeDevice": {
+          "type": "string",
+          "default": null,
+          "description": "%configuration.description.activeDevice%"
         }
       }
     }

--- a/package.nls.json
+++ b/package.nls.json
@@ -22,5 +22,6 @@
 
 	"configuration.title": ".NET Meteor configuration",
 	"configuration.description.monoSdbDebuggerPortAndroid": "Android's default port of the Mono SDB debugger.",
-	"configuration.description.monoSdbDebuggerPortApple": "iOS's default port of the Mono SDB debugger."
+	"configuration.description.monoSdbDebuggerPortApple": "iOS's default port of the Mono SDB debugger.",
+	"configuration.description.activeDevice": "The current active device."	
 }

--- a/src/VSCode.Extension/configuration.ts
+++ b/src/VSCode.Extension/configuration.ts
@@ -27,6 +27,14 @@ export class Configuration {
         return -1;
     }
 
+    public static getActiveDevice(): string | undefined {
+        const activeDevice = Configuration.getSetting(
+            res.configIdActiveDevice, 
+            res.configDefaultActiveDevice
+        )
+        return activeDevice ?? undefined;
+    }
+
     public static isAndroid() { return Configuration.device?.platform?.includes('android') ?? false; }
     public static isApple() { return Configuration.device?.platform?.includes('ios') ?? false; }
     public static isMacCatalyst() { return Configuration.device?.platform?.includes('maccatalyst') ?? false; }

--- a/src/VSCode.Extension/controller.ts
+++ b/src/VSCode.Extension/controller.ts
@@ -41,7 +41,8 @@ export class UIController {
         }
 
         Configuration.project = UIController.projects.find(it => it.name === Configuration.project?.name);
-        Configuration.device = UIController.devices.find(it => it.name === Configuration.device?.name);
+        const defaultDevice = Configuration.device?.name ?? Configuration.getActiveDevice();
+        Configuration.device = UIController.devices.find(it => it.name === defaultDevice);
 
         UIController.performSelectProject(Configuration.project);
         UIController.performSelectTarget(Configuration.target);

--- a/src/VSCode.Extension/resources.ts
+++ b/src/VSCode.Extension/resources.ts
@@ -35,3 +35,6 @@ export const configDefaultMonoSdbDebuggerPortAndroid = 10000;
 
 export const configIdMonoSdbDebuggerPortApple = "monoSdbDebuggerPortApple";
 export const configDefaultMonoSdbDebuggerPortApple = 55551;
+
+export const configIdActiveDevice = "activeDevice";
+export const configDefaultActiveDevice = null;


### PR DESCRIPTION
   - Settable in `User Settings`
   - Settable in `Workspace Settings`
   - The name entered is the text name of the device returned from all devices.

Solves a problem (close #44 )with the first device being selected as default.  This mod will allow a specific device to always be selected when the project is loaded.

- Device defaulted to first device in the devices.
   
   - <img width="873" alt="active device before" src="https://user-images.githubusercontent.com/640466/221592983-788258ee-e262-4e47-884a-506058655990.png">

- Developer wants to always start with `Mac` device instead of android as that is what the focus is on now.
   
   -  <img width="569" alt="active device setting add setting" src="https://user-images.githubusercontent.com/640466/221593579-67ea7d9e-31e3-4706-abef-94a78221a69f.png">

- Reload or refresh window to prompt an update
   
   -  <img width="871" alt="active device after" src="https://user-images.githubusercontent.com/640466/221594167-62e82c12-2e81-4705-8bc7-6ff024f822d5.png">

