### PR TITLE
add the ability to provide a different jdk path for the debugger in l…

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,26 @@ Your can build and debug projects, written in the `F#` language.
 
 ![image](https://github.com/JaneySprings/DotNet.Meteor/raw/main/assets/demo_dbg.gif)
 
+## Override Environment Variables
+
+You can provide environment-specific overrides for the debugger through the env property in the `launch.json` file.
+For example, to specify an alternative Java SDK to be used for Android builds (without modifying the system-wide `JAVA_HOME`), you can add the following configuration:
+```json
+{
+    "name": ".NET Meteor Debugger",
+    "type": "dotnet-meteor.debugger",
+    "request": "launch",
+    "env": {
+        "DOTNET_METEOR_JAVA_HOME": "/path/to/your/jdk"
+    },
+    "preLaunchTask": "dotnet-meteor: Build"
+}
+```
+
+When set, `DOTNET_METEOR_JAVA_HOME` is used to configure the Java SDK for Android builds.
+If not provided, the debugger falls back to the default MAUI Java resolution behavior (e.g. `JAVA_HOME`).
+
+**Note:** Currently, only Java SDK selection is supported via environment overrides.
 
 ## Enable XAML Hot Reload
 

--- a/src/VSCode/controllers/configurationController.ts
+++ b/src/VSCode/controllers/configurationController.ts
@@ -13,6 +13,7 @@ export class ConfigurationController {
     public static project: Project | undefined;
     public static device: Device | undefined;
     public static configuration: string | undefined;
+    public static overrideEnvironments: { [key: string]: string } | undefined;
 
     public static onWindows: boolean = process.platform === 'win32';
     public static onLinux: boolean = process.platform === 'linux';

--- a/src/VSCode/interop/interop.ts
+++ b/src/VSCode/interop/interop.ts
@@ -34,6 +34,10 @@ export class Interop {
         return ProcessRunner.runSync(new ProcessArgumentBuilder(Interop.workspaceToolPath)
             .append("--android-sdk-path"));
     }
+
+    public static getOverrideJDKPath(): string | undefined {
+        return ConfigurationController.overrideEnvironments?.['DOTNET_METEOR_JAVA_HOME'];
+    }
     public static getPropertyValue(propertyName: string, project: Project, configuration: string, device: Device) : string | undefined {
         const targetFramework = ConfigurationController.getTargetFramework();
         const runtimeIdentifier = device?.runtime_id;

--- a/src/VSCode/providers/dotnetTaskProvider.ts
+++ b/src/VSCode/providers/dotnetTaskProvider.ts
@@ -3,6 +3,7 @@ import { ConfigurationController } from '../controllers/configurationController'
 import { RemoteHostProvider } from '../features/removeHostProvider';
 import * as res from '../resources/constants';
 import * as vscode from 'vscode';
+import { Interop } from '../interop/interop';
 
 
 export class DotNetTaskProvider implements vscode.TaskProvider {
@@ -20,9 +21,11 @@ export class DotNetTaskProvider implements vscode.TaskProvider {
             .append(`-p:Configuration=${ConfigurationController.configuration}`)
             .append(`-p:TargetFramework=${ConfigurationController.getTargetFramework()}`)
             .conditional(`-p:RuntimeIdentifier=${ConfigurationController.device?.runtime_id}`, () => ConfigurationController.device?.runtime_id)
+            
 
         if (ConfigurationController.isAndroid()) {
             builder.append(`-p:AndroidSdkDirectory=${ConfigurationController.androidSdkDirectory}`);
+            builder.conditional(`-p:JavaSdkDirectory=${Interop.getOverrideJDKPath()}`, () => Interop.getOverrideJDKPath());
             builder.conditional('-p:EmbedAssembliesIntoApk=true', () => ConfigurationController.profiler);
             builder.conditional('-p:AndroidEnableProfiler=true', () => ConfigurationController.profiler);
             // TODO: https://github.com/dotnet/android/issues/9567

--- a/src/VSCode/providers/monoDebugConfigurationProvider.ts
+++ b/src/VSCode/providers/monoDebugConfigurationProvider.ts
@@ -10,6 +10,12 @@ export class MonoDebugConfigurationProvider implements vscode.DebugConfiguration
 		
 		ConfigurationController.profiler = config.profilerMode;
 		ConfigurationController.noDebug = config.noDebug;
+		/*
+		  add the ability for the user to override environment variables
+		  through the launch.json 'env' property without modifying the 
+		  system environment variables
+		*/
+		ConfigurationController.overrideEnvironments = config?.env;
 		
 		if (!ConfigurationController.isActive())
 			return undefined;


### PR DESCRIPTION
# Summary

This PR introduces support for overriding the Java SDK used for Android builds by setting a new environment variable in `launch.json`: **`DOTNET_METEOR_JAVA_HOME`**.

When provided, its value is forwarded to MSBuild via `-p:JavaSdkDirectory`, allowing developers to choose a specific JDK for .NET MAUI Android builds without modifying the global `JAVA_HOME`.

---

# Motivation

.NET MAUI Android builds are sensitive to JDK versions, and support for newer Java releases frequently lags behind their official availability. Developers who upgrade their system-wide JDK may find that MAUI Android builds fail until tooling catches up.

Current workarounds—such as downgrading Java or altering `JAVA_HOME`—are intrusive and affect unrelated tools, particularly for developers who maintain multiple JDK installations.

---

# Proposed Behavior

- If **`DOTNET_METEOR_JAVA_HOME`** is set:  
  Its value is passed to MSBuild via `-p:JavaSdkDirectory`, determining which JDK is used for Android builds.

- If the variable is **not** set:  
  No Java-related MSBuild properties are modified. The build continues to rely on `JAVA_HOME` or the default JDK supplied by the Android workload.

This change is opt‑in and fully backward‑compatible.

---

# Benefits

- Enables side-by-side JDK installations  
- Avoids modifying global `JAVA_HOME`  
- Scopes JDK selection to the project or debug profile  
- Aligns with standard VS Code `launch.json` environment override patterns  
- Preserves existing behavior by default  

---

# Example `launch.json`

```json
{
    "name": ".NET Meteor Debugger",
    "type": "dotnet-meteor.debugger",
    "request": "launch",
    "env": {
        "DOTNET_METEOR_JAVA_HOME": "/path/to/your/jdk"
    },
    "preLaunchTask": "dotnet-meteor: Build"
}
```
With this setup, developers can:

- Keep JDK  installed system‑wide
- Use alternative JDK  strictly for MAUI Android builds
- Avoid modifying `JAVA_HOME` entirely