### PR TITLE
Implement .aab debugging

### DIFF
--- a/src/DotNet.Meteor.Common/Android/AndroidBundleTool.cs
+++ b/src/DotNet.Meteor.Common/Android/AndroidBundleTool.cs
@@ -9,6 +9,9 @@ public static class AndroidBundleTool {
         var adb = AndroidSdkLocator.AdbTool();
         var aapt2 = AndroidSdkLocator.Aapt2Tool();
 
+        if (File.Exists(apksOutputPath))
+            File.Delete(apksOutputPath);
+
         var arguments = new ProcessArgumentBuilder()
             .Append("-Xmx1G")
             .Append("-jar").AppendQuoted(bundleTool.FullName)

--- a/src/DotNet.Meteor.Common/Android/AndroidBundleTool.cs
+++ b/src/DotNet.Meteor.Common/Android/AndroidBundleTool.cs
@@ -1,0 +1,57 @@
+using DotNet.Meteor.Common.Processes;
+
+namespace DotNet.Meteor.Common.Android;
+
+public static class AndroidBundleTool {
+    public static void BuildApks(string aabPath, string apksOutputPath, string serial, KeystoreInfo keystore, string? extraArgs, IProcessLogger? logger = null) {
+        var java = AndroidSdkLocator.JavaTool();
+        var bundleTool = AndroidSdkLocator.BundleToolJar();
+        var adb = AndroidSdkLocator.AdbTool();
+        var aapt2 = AndroidSdkLocator.Aapt2Tool();
+
+        var arguments = new ProcessArgumentBuilder()
+            .Append("-Xmx1G")
+            .Append("-jar").AppendQuoted(bundleTool.FullName)
+            .Append("build-apks")
+            .Append("--connected-device")
+            .Append("--mode", "default")
+            .Append("--adb").AppendQuoted(adb.FullName)
+            .Append("--device-id", serial)
+            .Append("--bundle").AppendQuoted(aabPath)
+            .Append("--output").AppendQuoted(apksOutputPath)
+            .Append("--aapt2").AppendQuoted(aapt2.FullName)
+            .Append("--ks").AppendQuoted(keystore.KeyStorePath)
+            .Append("--ks-key-alias", keystore.KeyAlias)
+            .Append("--key-pass", $"pass:{keystore.KeyPass}")
+            .Append("--ks-pass", $"pass:{keystore.StorePass}");
+
+        if (!string.IsNullOrWhiteSpace(extraArgs)) {
+            foreach (var arg in extraArgs.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+                arguments.Append(arg);
+        }
+
+        var result = new ProcessRunner(java, arguments, logger).WaitForExit();
+        if (!result.Success)
+            throw new InvalidOperationException(string.Join(Environment.NewLine, result.StandardError));
+    }
+
+    public static void InstallApks(string apksPath, string serial, IProcessLogger? logger = null) {
+        var java = AndroidSdkLocator.JavaTool();
+        var bundleTool = AndroidSdkLocator.BundleToolJar();
+        var adb = AndroidSdkLocator.AdbTool();
+
+        var arguments = new ProcessArgumentBuilder()
+            .Append("-Xmx1G")
+            .Append("-jar").AppendQuoted(bundleTool.FullName)
+            .Append("install-apks")
+            .Append("--apks").AppendQuoted(apksPath)
+            .Append("--adb").AppendQuoted(adb.FullName)
+            .Append("--device-id", serial)
+            .Append("--allow-downgrade")
+            .Append("--modules", "_ALL_");
+
+        var result = new ProcessRunner(java, arguments, logger).WaitForExit();
+        if (!result.Success)
+            throw new InvalidOperationException(string.Join(Environment.NewLine, result.StandardError));
+    }
+}

--- a/src/DotNet.Meteor.Common/Android/AndroidDebugBridge.cs
+++ b/src/DotNet.Meteor.Common/Android/AndroidDebugBridge.cs
@@ -38,7 +38,7 @@ public static class AndroidDebugBridge {
         if (!result.Success)
             throw new InvalidOperationException(string.Join(Environment.NewLine, result.StandardError));
 
-        string regex = @"^(?<serial>\S+?)(\s+?)\s+(?<state>\S+)";
+        string regex = @"^(?<serial>\S+)\s+(?<state>\S+)";
         var devices = new List<string>();
 
         foreach (string line in result.StandardOutput) {

--- a/src/DotNet.Meteor.Common/Android/AndroidDebugBridge.cs
+++ b/src/DotNet.Meteor.Common/Android/AndroidDebugBridge.cs
@@ -41,7 +41,7 @@ public static class AndroidDebugBridge {
         string regex = @"^(?<serial>\S+)\s+(?<state>\S+)";
         var devices = new List<string>();
 
-        foreach (string line in result.StandardOutput) {
+        foreach (string line in result.StandardOutput.Skip(1)) { // Skip "List of devices attached"
             MatchCollection matches = Regex.Matches(line, regex, RegexOptions.Singleline);
             if (matches.Count == 0)
                 continue;

--- a/src/DotNet.Meteor.Common/Android/AndroidSdkLocator.cs
+++ b/src/DotNet.Meteor.Common/Android/AndroidSdkLocator.cs
@@ -1,5 +1,3 @@
-using DotNet.Meteor.Common.Apple;
-
 namespace DotNet.Meteor.Common.Android;
 
 public static class AndroidSdkLocator {
@@ -34,6 +32,7 @@ public static class AndroidSdkLocator {
 
         return string.Empty;
     }
+
     public static string AvdLocation() {
         var path = Environment.GetEnvironmentVariable("ANDROID_AVD_HOME");
         if (!string.IsNullOrEmpty(path) && Directory.Exists(path))
@@ -51,6 +50,7 @@ public static class AndroidSdkLocator {
 
         return new FileInfo(path);
     }
+
     public static FileInfo EmulatorTool() {
         string sdk = AndroidSdkLocator.SdkLocation();
         string path = Path.Combine(sdk, "emulator", "emulator" + RuntimeSystem.ExecExtension);
@@ -60,19 +60,22 @@ public static class AndroidSdkLocator {
 
         return new FileInfo(path);
     }
+
     public static FileInfo AvdTool() {
         string sdk = AndroidSdkLocator.SdkLocation();
         string tools = Path.Combine(sdk, "cmdline-tools");
         FileInfo? newestTool = null;
 
-        foreach (string directory in Directory.GetDirectories(tools)) {
-            string avdPath = Path.Combine(directory, "bin", "avdmanager" + RuntimeSystem.ExecExtension);
+        if (Directory.Exists(tools)) {
+            foreach (string directory in Directory.GetDirectories(tools)) {
+                string avdPath = Path.Combine(directory, "bin", "avdmanager" + RuntimeSystem.ExecExtension);
 
-            if (File.Exists(avdPath)) {
-                var tool = new FileInfo(avdPath);
+                if (File.Exists(avdPath)) {
+                    var tool = new FileInfo(avdPath);
 
-                if (newestTool == null || tool.CreationTime > newestTool.CreationTime)
-                    newestTool = tool;
+                    if (newestTool == null || tool.CreationTime > newestTool.CreationTime)
+                        newestTool = tool;
+                }
             }
         }
 
@@ -81,28 +84,74 @@ public static class AndroidSdkLocator {
 
         return newestTool;
     }
+
     public static FileInfo BundleToolJar() {
-        var dotnetPacksPath = Path.Combine(AppleSdkLocator.DotNetRootLocation(), "packs");
-        foreach (var sdkDir in Directory.GetDirectories(dotnetPacksPath, "Microsoft.Android.Sdk.*").OrderByDescending(x => x)) {
-            foreach (var versionDir in Directory.GetDirectories(sdkDir).OrderByDescending(x => x)) {
-                var candidate = Path.Combine(versionDir, "tools", "bundletool.jar");
+        // 1) Try Android SDK locations first.
+        string sdk = AndroidSdkLocator.SdkLocation();
+        var sdkCandidates = new List<FileInfo>();
+
+        var cmdlineToolsPath = Path.Combine(sdk, "cmdline-tools");
+        if (Directory.Exists(cmdlineToolsPath)) {
+            foreach (var directory in Directory.GetDirectories(cmdlineToolsPath)) {
+                var candidate = Path.Combine(directory, "lib", "bundletool.jar");
                 if (File.Exists(candidate))
-                    return new FileInfo(candidate);
+                    sdkCandidates.Add(new FileInfo(candidate));
             }
         }
-        throw new FileNotFoundException("Could not find bundletool.jar in dotnet Android SDK packs");
+
+        var legacyCandidate = Path.Combine(sdk, "tools", "lib", "bundletool.jar");
+        if (File.Exists(legacyCandidate))
+            sdkCandidates.Add(new FileInfo(legacyCandidate));
+
+        var newestSdkTool = sdkCandidates.OrderByDescending(x => x.CreationTime).FirstOrDefault();
+        if (newestSdkTool != null && newestSdkTool.Exists)
+            return newestSdkTool;
+
+        // 2) Fallback to dotnet Android packs (cross-platform).
+        var packCandidates = FindAndroidPackTools("bundletool.jar");
+        var newestPackTool = packCandidates.OrderByDescending(x => x.CreationTime).FirstOrDefault();
+        if (newestPackTool != null && newestPackTool.Exists)
+            return newestPackTool;
+
+        throw new FileNotFoundException("Could not find bundletool.jar in Android SDK or dotnet Android packs");
     }
+
     public static FileInfo Aapt2Tool() {
-        var dotnetPacksPath = Path.Combine(AppleSdkLocator.DotNetRootLocation(), "packs");
-        foreach (var sdkDir in Directory.GetDirectories(dotnetPacksPath, "Microsoft.Android.Sdk.*").OrderByDescending(x => x)) {
-            foreach (var versionDir in Directory.GetDirectories(sdkDir).OrderByDescending(x => x)) {
-                var candidate = Path.Combine(versionDir, "tools", "aapt2" + RuntimeSystem.ExecExtension);
+        // 1) Try Android SDK locations first.
+        string sdk = AndroidSdkLocator.SdkLocation();
+        var sdkCandidates = new List<FileInfo>();
+
+        var buildToolsPath = Path.Combine(sdk, "build-tools");
+        if (Directory.Exists(buildToolsPath)) {
+            foreach (var directory in Directory.GetDirectories(buildToolsPath)) {
+                var candidate = Path.Combine(directory, "aapt2" + RuntimeSystem.ExecExtension);
                 if (File.Exists(candidate))
-                    return new FileInfo(candidate);
+                    sdkCandidates.Add(new FileInfo(candidate));
             }
         }
-        throw new FileNotFoundException("Could not find aapt2 tool in dotnet Android SDK packs");
+
+        var cmdlineToolsPath = Path.Combine(sdk, "cmdline-tools");
+        if (Directory.Exists(cmdlineToolsPath)) {
+            foreach (var directory in Directory.GetDirectories(cmdlineToolsPath)) {
+                var candidate = Path.Combine(directory, "bin", "aapt2" + RuntimeSystem.ExecExtension);
+                if (File.Exists(candidate))
+                    sdkCandidates.Add(new FileInfo(candidate));
+            }
+        }
+
+        var newestSdkTool = sdkCandidates.OrderByDescending(x => x.CreationTime).FirstOrDefault();
+        if (newestSdkTool != null && newestSdkTool.Exists)
+            return newestSdkTool;
+
+        // 2) Fallback to dotnet Android packs (cross-platform).
+        var packCandidates = FindAndroidPackTools("aapt2" + RuntimeSystem.ExecExtension);
+        var newestPackTool = packCandidates.OrderByDescending(x => x.CreationTime).FirstOrDefault();
+        if (newestPackTool != null && newestPackTool.Exists)
+            return newestPackTool;
+
+        throw new FileNotFoundException("Could not find aapt2 tool in Android SDK or dotnet Android packs");
     }
+
     public static FileInfo JavaTool() {
         // 1. Check JAVA_HOME
         var javaHome = Environment.GetEnvironmentVariable("JAVA_HOME");
@@ -111,7 +160,18 @@ public static class AndroidSdkLocator {
             if (File.Exists(path))
                 return new FileInfo(path);
         }
-        // 2. Check Visual Studio's bundled OpenJDK on Windows (Program Files\Android\openjdk\jdk-*)
+
+        // 2. macOS: use /usr/libexec/java_home
+        if (RuntimeSystem.IsMacOS) {
+            var javaHomeResult = TryRunAndCapture("/usr/libexec/java_home", "");
+            if (!string.IsNullOrWhiteSpace(javaHomeResult) && Directory.Exists(javaHomeResult)) {
+                var path = Path.Combine(javaHomeResult, "bin", "java");
+                if (File.Exists(path))
+                    return new FileInfo(path);
+            }
+        }
+
+        // 3. Check Visual Studio's bundled OpenJDK on Windows (Program Files\Android\openjdk\jdk-*)
         if (RuntimeSystem.IsWindows) {
             var programFiles = Environment.GetEnvironmentVariable("ProgramFiles") ?? @"C:\Program Files";
             var openjdkDir = Path.Combine(programFiles, "Android", "openjdk");
@@ -123,6 +183,133 @@ public static class AndroidSdkLocator {
                 }
             }
         }
-        throw new FileNotFoundException("Could not find java tool. Set the JAVA_HOME environment variable.");
+
+        // 4. Fallback to PATH lookup
+        if (RuntimeSystem.IsWindows) {
+            var whereResult = TryRunAndCapture("where", "java");
+            var first = whereResult?.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+            if (!string.IsNullOrWhiteSpace(first) && File.Exists(first))
+                return new FileInfo(first);
+        } else {
+            var whichResult = TryRunAndCapture("which", "java");
+            if (!string.IsNullOrWhiteSpace(whichResult) && File.Exists(whichResult))
+                return new FileInfo(whichResult);
+        }
+
+        throw new FileNotFoundException("Could not find java tool. Set JAVA_HOME or ensure java is available on PATH.");
+    }
+
+    private static IEnumerable<FileInfo> FindAndroidPackTools(string toolFileName) {
+        var candidates = new List<FileInfo>();
+        var dotnetRoots = GetDotnetRoots();
+
+        foreach (var dotnetRoot in dotnetRoots) {
+            var packsPath = Path.Combine(dotnetRoot, "packs");
+            if (!Directory.Exists(packsPath))
+                continue;
+
+            foreach (var packName in GetAndroidPackNamesForCurrentPlatform()) {
+                var packRoot = Path.Combine(packsPath, packName);
+                if (!Directory.Exists(packRoot))
+                    continue;
+
+                foreach (var versionDir in Directory.GetDirectories(packRoot).OrderByDescending(x => x)) {
+                    var candidate = Path.Combine(versionDir, "tools", toolFileName);
+                    if (File.Exists(candidate))
+                        candidates.Add(new FileInfo(candidate));
+                }
+            }
+
+            // Additional broad fallback in case naming conventions evolve.
+            foreach (var packRoot in Directory.GetDirectories(packsPath, "Microsoft.Android.Sdk*")) {
+                foreach (var versionDir in Directory.GetDirectories(packRoot).OrderByDescending(x => x)) {
+                    var candidate = Path.Combine(versionDir, "tools", toolFileName);
+                    if (File.Exists(candidate))
+                        candidates.Add(new FileInfo(candidate));
+                }
+            }
+        }
+
+        return candidates;
+    }
+
+    private static IEnumerable<string> GetAndroidPackNamesForCurrentPlatform() {
+        if (RuntimeSystem.IsWindows)
+            return new[] { "Microsoft.Android.Sdk.Windows", "Microsoft.Android.Sdk" };
+        if (RuntimeSystem.IsMacOS)
+            return new[] { "Microsoft.Android.Sdk.Darwin", "Microsoft.Android.Sdk.macOS", "Microsoft.Android.Sdk" };
+
+        return new[] { "Microsoft.Android.Sdk.Linux", "Microsoft.Android.Sdk" };
+    }
+
+    private static IEnumerable<string> GetDotnetRoots() {
+        var roots = new List<string>();
+
+        var envRoot = Environment.GetEnvironmentVariable("DOTNET_ROOT");
+        if (!string.IsNullOrWhiteSpace(envRoot) && Directory.Exists(envRoot))
+            roots.Add(envRoot);
+
+        // Try to infer dotnet root from `dotnet --list-sdks` output:
+        // "<version> [<dotnetRoot>/sdk]"
+        var sdkList = TryRunAndCapture("dotnet", "--list-sdks");
+        if (!string.IsNullOrWhiteSpace(sdkList)) {
+            var lines = sdkList.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var line in lines) {
+                var openBracket = line.IndexOf('[');
+                var closeBracket = line.IndexOf(']');
+                if (openBracket >= 0 && closeBracket > openBracket) {
+                    var sdkPath = line.Substring(openBracket + 1, closeBracket - openBracket - 1).Trim();
+                    if (Directory.Exists(sdkPath)) {
+                        var sdkDir = new DirectoryInfo(sdkPath);
+                        if (sdkDir.Name.Equals("sdk", StringComparison.OrdinalIgnoreCase) && sdkDir.Parent != null) {
+                            var root = sdkDir.Parent.FullName;
+                            if (Directory.Exists(root))
+                                roots.Add(root);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Common defaults as a final fallback.
+        if (RuntimeSystem.IsWindows)
+            roots.Add(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "dotnet"));
+        else if (RuntimeSystem.IsMacOS)
+            roots.Add("/usr/local/share/dotnet");
+        else
+            roots.Add("/usr/share/dotnet");
+
+        return roots
+            .Where(Directory.Exists)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    private static string? TryRunAndCapture(string fileName, string arguments) {
+        try {
+            var psi = new System.Diagnostics.ProcessStartInfo {
+                FileName = fileName,
+                Arguments = arguments,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
+
+            using var process = System.Diagnostics.Process.Start(psi);
+            if (process == null)
+                return null;
+
+            string output = process.StandardOutput.ReadToEnd();
+            process.WaitForExit();
+
+            if (process.ExitCode != 0)
+                return null;
+
+            return output.Trim();
+        }
+        catch {
+            return null;
+        }
     }
 }

--- a/src/DotNet.Meteor.Common/Android/AndroidSdkLocator.cs
+++ b/src/DotNet.Meteor.Common/Android/AndroidSdkLocator.cs
@@ -1,3 +1,5 @@
+using DotNet.Meteor.Common.Apple;
+
 namespace DotNet.Meteor.Common.Android;
 
 public static class AndroidSdkLocator {
@@ -78,5 +80,49 @@ public static class AndroidSdkLocator {
             throw new FileNotFoundException("Could not find avdmanager tool");
 
         return newestTool;
+    }
+    public static FileInfo BundleToolJar() {
+        var dotnetPacksPath = Path.Combine(AppleSdkLocator.DotNetRootLocation(), "packs");
+        foreach (var sdkDir in Directory.GetDirectories(dotnetPacksPath, "Microsoft.Android.Sdk.*").OrderByDescending(x => x)) {
+            foreach (var versionDir in Directory.GetDirectories(sdkDir).OrderByDescending(x => x)) {
+                var candidate = Path.Combine(versionDir, "tools", "bundletool.jar");
+                if (File.Exists(candidate))
+                    return new FileInfo(candidate);
+            }
+        }
+        throw new FileNotFoundException("Could not find bundletool.jar in dotnet Android SDK packs");
+    }
+    public static FileInfo Aapt2Tool() {
+        var dotnetPacksPath = Path.Combine(AppleSdkLocator.DotNetRootLocation(), "packs");
+        foreach (var sdkDir in Directory.GetDirectories(dotnetPacksPath, "Microsoft.Android.Sdk.*").OrderByDescending(x => x)) {
+            foreach (var versionDir in Directory.GetDirectories(sdkDir).OrderByDescending(x => x)) {
+                var candidate = Path.Combine(versionDir, "tools", "aapt2" + RuntimeSystem.ExecExtension);
+                if (File.Exists(candidate))
+                    return new FileInfo(candidate);
+            }
+        }
+        throw new FileNotFoundException("Could not find aapt2 tool in dotnet Android SDK packs");
+    }
+    public static FileInfo JavaTool() {
+        // 1. Check JAVA_HOME
+        var javaHome = Environment.GetEnvironmentVariable("JAVA_HOME");
+        if (!string.IsNullOrEmpty(javaHome)) {
+            var path = Path.Combine(javaHome, "bin", "java" + RuntimeSystem.ExecExtension);
+            if (File.Exists(path))
+                return new FileInfo(path);
+        }
+        // 2. Check Visual Studio's bundled OpenJDK on Windows (Program Files\Android\openjdk\jdk-*)
+        if (RuntimeSystem.IsWindows) {
+            var programFiles = Environment.GetEnvironmentVariable("ProgramFiles") ?? @"C:\Program Files";
+            var openjdkDir = Path.Combine(programFiles, "Android", "openjdk");
+            if (Directory.Exists(openjdkDir)) {
+                foreach (var jdkDir in Directory.GetDirectories(openjdkDir, "jdk-*").OrderByDescending(x => x)) {
+                    var path = Path.Combine(jdkDir, "bin", "java" + RuntimeSystem.ExecExtension);
+                    if (File.Exists(path))
+                        return new FileInfo(path);
+                }
+            }
+        }
+        throw new FileNotFoundException("Could not find java tool. Set the JAVA_HOME environment variable.");
     }
 }

--- a/src/DotNet.Meteor.Common/Models/KeyStoreInfo.cs
+++ b/src/DotNet.Meteor.Common/Models/KeyStoreInfo.cs
@@ -1,0 +1,8 @@
+namespace DotNet.Meteor.Common;
+
+public class KeystoreInfo {
+    public string KeyStorePath { get; set; } = string.Empty;
+    public string KeyAlias { get; set; } = string.Empty;
+    public string StorePass { get; set; } = string.Empty;
+    public string KeyPass { get; set; } = string.Empty;
+}

--- a/src/DotNet.Meteor.Debugger/Agents/DebugLaunchAgent.cs
+++ b/src/DotNet.Meteor.Debugger/Agents/DebugLaunchAgent.cs
@@ -92,7 +92,13 @@ public class DebugLaunchAgent : BaseLaunchAgent {
         if (Configuration.UninstallApp)
             AndroidDebugBridge.Uninstall(Configuration.Device.Serial, applicationId, logger);
 
-        AndroidDebugBridge.Install(Configuration.Device.Serial, Configuration.ProgramPath, logger);
+        if (Configuration.IsAab) {
+            var apksPath = Path.ChangeExtension(Configuration.ProgramPath, ".apks");
+            AndroidBundleTool.BuildApks(Configuration.ProgramPath, apksPath, Configuration.Device.Serial, Configuration.Keystore!, Configuration.BundleToolExtraArgs, logger);
+            AndroidBundleTool.InstallApks(apksPath, Configuration.Device.Serial, logger);
+        } else {
+            AndroidDebugBridge.Install(Configuration.Device.Serial, Configuration.ProgramPath, logger);
+        }
         AndroidDebugBridge.Shell(Configuration.Device.Serial, "setprop", "debug.mono.connect", $"port={Configuration.DebugPort}");
         if (Configuration.EnvironmentVariables.Count != 0)
             AndroidDebugBridge.Shell(Configuration.Device.Serial, "setprop", "debug.mono.env", Configuration.EnvironmentVariables.ToAndroidEnvString());

--- a/src/DotNet.Meteor.Debugger/Agents/GCDumpLaunchAgent.cs
+++ b/src/DotNet.Meteor.Debugger/Agents/GCDumpLaunchAgent.cs
@@ -87,7 +87,13 @@ public class GCDumpLaunchAgent : BaseLaunchAgent {
 
         if (Configuration.UninstallApp)
             AndroidDebugBridge.Uninstall(Configuration.Device.Serial, applicationId, logger);
-        AndroidDebugBridge.Install(Configuration.Device.Serial, Configuration.ProgramPath, logger);
+        if (Configuration.IsAab) {
+            var apksPath = Path.ChangeExtension(Configuration.ProgramPath, ".apks");
+            AndroidBundleTool.BuildApks(Configuration.ProgramPath, apksPath, Configuration.Device.Serial, Configuration.Keystore!, Configuration.BundleToolExtraArgs, logger);
+            AndroidBundleTool.InstallApks(apksPath, Configuration.Device.Serial, logger);
+        } else {
+            AndroidDebugBridge.Install(Configuration.Device.Serial, Configuration.ProgramPath, logger);
+        }
         AndroidDebugBridge.Launch(Configuration.Device.Serial, applicationId, logger);
 
         Disposables.Add(() => AndroidDebugBridge.Shell(Configuration.Device.Serial, "am", "force-stop", applicationId));

--- a/src/DotNet.Meteor.Debugger/Agents/NoDebugLaunchAgent.cs
+++ b/src/DotNet.Meteor.Debugger/Agents/NoDebugLaunchAgent.cs
@@ -61,7 +61,13 @@ public class NoDebugLaunchAgent : BaseLaunchAgent {
         if (Configuration.UninstallApp)
             AndroidDebugBridge.Uninstall(Configuration.Device.Serial, applicationId, logger);
 
-        AndroidDebugBridge.Install(Configuration.Device.Serial, Configuration.ProgramPath, logger);
+        if (Configuration.IsAab) {
+            var apksPath = Path.ChangeExtension(Configuration.ProgramPath, ".apks");
+            AndroidBundleTool.BuildApks(Configuration.ProgramPath, apksPath, Configuration.Device.Serial, Configuration.Keystore!, Configuration.BundleToolExtraArgs, logger);
+            AndroidBundleTool.InstallApks(apksPath, Configuration.Device.Serial, logger);
+        } else {
+            AndroidDebugBridge.Install(Configuration.Device.Serial, Configuration.ProgramPath, logger);
+        }
         if (Configuration.EnvironmentVariables.Count != 0)
             AndroidDebugBridge.Shell(Configuration.Device.Serial, "setprop", "debug.mono.env", Configuration.EnvironmentVariables.ToAndroidEnvString());
 

--- a/src/DotNet.Meteor.Debugger/Agents/TraceLaunchAgent.cs
+++ b/src/DotNet.Meteor.Debugger/Agents/TraceLaunchAgent.cs
@@ -81,7 +81,13 @@ public class TraceLaunchAgent : BaseLaunchAgent {
 
         if (Configuration.UninstallApp)
             AndroidDebugBridge.Uninstall(Configuration.Device.Serial, applicationId, logger);
-        AndroidDebugBridge.Install(Configuration.Device.Serial, Configuration.ProgramPath, logger);
+        if (Configuration.IsAab) {
+            var apksPath = Path.ChangeExtension(Configuration.ProgramPath, ".apks");
+            AndroidBundleTool.BuildApks(Configuration.ProgramPath, apksPath, Configuration.Device.Serial, Configuration.Keystore!, Configuration.BundleToolExtraArgs, logger);
+            AndroidBundleTool.InstallApks(apksPath, Configuration.Device.Serial, logger);
+        } else {
+            AndroidDebugBridge.Install(Configuration.Device.Serial, Configuration.ProgramPath, logger);
+        }
         AndroidDebugBridge.Launch(Configuration.Device.Serial, applicationId, logger);
 
         var traceProcess = Trace.Collect(routerProcess.Id, nettracePath, logger);

--- a/src/DotNet.Meteor.Debugger/LaunchConfiguration.cs
+++ b/src/DotNet.Meteor.Debugger/LaunchConfiguration.cs
@@ -16,8 +16,12 @@ public class LaunchConfiguration {
     public int ReloadHostPort { get; init; }
     public int ProfilerPort { get; init; }
     public string? TransportId { get; init; }
+    public KeystoreInfo? Keystore { get; init; }
+    public string BundleToolExtraArgs { get; init; }
     public Dictionary<string, string> EnvironmentVariables { get; init; }
     public DebuggerSessionOptions DebuggerSessionOptions { get; init; }
+
+    public bool IsAab => ProgramPath.EndsWith(".aab", StringComparison.OrdinalIgnoreCase);
 
     private ProfilerMode Profiler { get; init; }
     private bool SkipDebug { get; init; }
@@ -46,6 +50,8 @@ public class LaunchConfiguration {
             ProgramPath = FindProgramPath(ProgramPath); // Last chance to get program path
 
         AssetsPath = Project.GetRelativePath(configurationProperties.TryGetValue("assets").ToClass<string>());
+        Keystore = configurationProperties.TryGetValue("keystoreInfo")?.ToClass<KeystoreInfo>();
+        BundleToolExtraArgs = configurationProperties.TryGetValue("bundleToolExtraArgs").ToClass<string>() ?? string.Empty;
     }
 
     public string GetApplicationName() {
@@ -95,6 +101,11 @@ public class LaunchConfiguration {
             var apkPaths = Directory.GetFiles(programDirectory, "*-Signed.apk");
             if (apkPaths.Length == 1)
                 return apkPaths[0];
+            var aabPaths = Directory.GetFiles(programDirectory, "*.aab")
+                .Where(p => !p.EndsWith("-Signed.aab", StringComparison.OrdinalIgnoreCase))
+                .ToArray();
+            if (aabPaths.Length == 1)
+                return aabPaths[0];
         }
         if (Device.IsMacCatalyst || Device.IsIPhone) {
             var appExtension = RuntimeSystem.IsMacOS ? ".app" : ".ipa";

--- a/src/VSCode/controllers/configurationController.ts
+++ b/src/VSCode/controllers/configurationController.ts
@@ -161,8 +161,12 @@ export class ConfigurationController {
         if (ConfigurationController.isAndroid()) {
             const outDir = path.dirname(targetPath);
             const packageName = Interop.getPropertyValue('ApplicationId', project, configuration, device);
-            if (packageName !== undefined)
+            if (packageName !== undefined) {
+                const packageFormat = Interop.getPropertyValue('AndroidPackageFormat', project, configuration, device);
+                if (packageFormat?.toLowerCase() === 'aab')
+                    return path.join(outDir, packageName + '.aab');
                 return path.join(outDir, packageName + '-Signed.apk');
+            }
         }
         if (ConfigurationController.isAppleMobile() || ConfigurationController.isMacCatalyst()) {
             const outDir = path.dirname(targetPath);
@@ -180,5 +184,29 @@ export class ConfigurationController {
 
         const assembliesDir = Interop.getPropertyValue('MonoAndroidIntermediateAssemblyDir', project, configuration, device);
         return assembliesDir;
+    }
+    public static getKeystoreInfo(project: Project, configuration: string, device: Device): any {
+        const useCustomKeystore = Interop.getPropertyValue('AndroidKeyStore', project, configuration, device);
+        if (useCustomKeystore?.toLowerCase() === 'true') {
+            return {
+                keyStorePath: Interop.getPropertyValue('AndroidSigningKeyStore', project, configuration, device),
+                keyAlias: Interop.getPropertyValue('AndroidSigningKeyAlias', project, configuration, device),
+                storePass: Interop.getPropertyValue('AndroidSigningStorePass', project, configuration, device),
+                keyPass: Interop.getPropertyValue('AndroidSigningKeyPass', project, configuration, device),
+            };
+        }
+        // Default Xamarin/Android debug keystore
+        const debugKeystore = ConfigurationController.onWindows
+            ? path.join(process.env['LOCALAPPDATA'] ?? '', 'Xamarin', 'Mono for Android', 'debug.keystore')
+            : path.join(process.env['HOME'] ?? '', '.android', 'debug.keystore');
+        return {
+            keyStorePath: debugKeystore,
+            keyAlias: 'androiddebugkey',
+            storePass: 'android',
+            keyPass: 'android',
+        };
+    }
+    public static getBundleToolExtraArgs(project: Project, configuration: string, device: Device): string | undefined {
+        return Interop.getPropertyValue('AndroidBundleToolExtraArgs', project, configuration, device);
     }
 } 

--- a/src/VSCode/controllers/configurationController.ts
+++ b/src/VSCode/controllers/configurationController.ts
@@ -5,6 +5,7 @@ import { Device } from '../models/device';
 import * as res from '../resources/constants';
 import * as vscode from 'vscode';
 import * as path from 'path';
+import * as fs from 'fs';
 
 export class ConfigurationController {
     public static androidSdkDirectory: string | undefined;
@@ -195,10 +196,23 @@ export class ConfigurationController {
                 keyPass: Interop.getPropertyValue('AndroidSigningKeyPass', project, configuration, device),
             };
         }
-        // Default Xamarin/Android debug keystore
-        const debugKeystore = ConfigurationController.onWindows
-            ? path.join(process.env['LOCALAPPDATA'] ?? '', 'Xamarin', 'Mono for Android', 'debug.keystore')
-            : path.join(process.env['HOME'] ?? '', '.android', 'debug.keystore');
+
+        const homeDirectory = process.env['HOME'] ?? '';
+        const localAppData = process.env['LOCALAPPDATA'] ?? '';
+        const candidates: string[] = ConfigurationController.onWindows
+            ? [path.join(localAppData, 'Xamarin', 'Mono for Android', 'debug.keystore')]
+            : ConfigurationController.onMac
+                ? [
+                    path.join(homeDirectory, 'Library', 'Application Support', 'Xamarin', 'Mono for Android', 'debug.keystore'),
+                    path.join(homeDirectory, '.android', 'debug.keystore'),
+                    path.join(homeDirectory, '.local', 'share', 'Xamarin', 'Mono for Android', 'debug.keystore'),
+                ]
+                : [
+                    path.join(homeDirectory, '.android', 'debug.keystore'),
+                    path.join(homeDirectory, '.local', 'share', 'Xamarin', 'Mono for Android', 'debug.keystore'),
+                ];
+
+        const debugKeystore = candidates.find(it => fs.existsSync(it)) ?? candidates[0];
         return {
             keyStorePath: debugKeystore,
             keyAlias: 'androiddebugkey',
@@ -209,4 +223,4 @@ export class ConfigurationController {
     public static getBundleToolExtraArgs(project: Project, configuration: string, device: Device): string | undefined {
         return Interop.getPropertyValue('AndroidBundleToolExtraArgs', project, configuration, device);
     }
-} 
+}

--- a/src/VSCode/providers/monoDebugConfigurationProvider.ts
+++ b/src/VSCode/providers/monoDebugConfigurationProvider.ts
@@ -36,6 +36,12 @@ export class MonoDebugConfigurationProvider implements vscode.DebugConfiguration
 			config.program = ConfigurationController.getProgramPath(config.project, config.configuration, config.device);
 		if (config.assets === undefined)
 			config.assets = ConfigurationController.getAssetsPath(config.project, config.configuration, config.device);
+		if (ConfigurationController.isAndroid() && config.program?.endsWith('.aab')) {
+			if (config.keystoreInfo === undefined)
+				config.keystoreInfo = ConfigurationController.getKeystoreInfo(config.project, config.configuration, config.device);
+			if (config.bundleToolExtraArgs === undefined)
+				config.bundleToolExtraArgs = ConfigurationController.getBundleToolExtraArgs(config.project, config.configuration, config.device);
+		}
 
 		if (ConfigurationController.isVsdbgRequired()) {
 			config.type = res.debuggerVsdbgId;


### PR DESCRIPTION
Implements #178 

Test project: https://github.com/bryanedds/Nu/blob/0140029ea5de27739e443bdfc96a6ab4ab1481c4/Projects/Sand%20Box%202d/Sand%20Box%202d.fsproj

Additional fix: `adb devices -l` for [WiFi debugging](https://developer.android.com/tools/adb#wireless-android11-command-line) can produce a long device name:
```
List of devices attached
adb-DE55QCSWGA85JJIR-G3xwBZ._adb-tls-connect._tcp device product:zircon_global model:23090RA98G device:zircon transport_id:1
```

However, the current regex that reads device serials expects two or more spaces as a workaround for skipping "List of devices attached". It is now changed to skip the first line instead, and only match one space for lines that come later.